### PR TITLE
Fix: when click any rule, it always enter the first one.

### DIFF
--- a/app/src/main/java/com/kaisar/xposed/godmode/fragment/ViewRuleDetailsContainerFragment.java
+++ b/app/src/main/java/com/kaisar/xposed/godmode/fragment/ViewRuleDetailsContainerFragment.java
@@ -92,8 +92,10 @@ public final class ViewRuleDetailsContainerFragment extends PreferenceFragmentCo
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        DetailFragmentStateAdapter detailFragmentStateAdapter= new DetailFragmentStateAdapter(this);
+        detailFragmentStateAdapter.setData(mSharedViewModel.actRules.getValue());
         mViewPager = (ViewPager2) inflater.inflate(R.layout.fragment_rule_details_container, container, false);
-        mViewPager.setAdapter(new DetailFragmentStateAdapter(this));
+        mViewPager.setAdapter(detailFragmentStateAdapter);
         mViewPager.registerOnPageChangeCallback(mCallback);
         mViewPager.setCurrentItem(mCurIndex);
         return mViewPager;


### PR DESCRIPTION
`setCurrentItem` will not work when its adapter has 0 item.

And mViewPager sets a empty adapter ( `new DetailFragmentStateAdapter(this)` )

![image](https://user-images.githubusercontent.com/3889846/159505311-0960f390-aaa9-454e-a0c6-12773960fde4.png)

In this case, `getCurrentItem` will always be set to 0, cause `mCurIndex` is always 0.